### PR TITLE
Remove commented line before parsing

### DIFF
--- a/QMLFile.js
+++ b/QMLFile.js
@@ -71,6 +71,13 @@ QMLFile.prototype.makeKey = function(source) {
     return QMLFile.unescapeString(source);
 };
 
+/**
+* Remove single and multi-lines comments except for i18n comment style.
+*
+* @private
+* @param {String} string the string to clean
+* @returns {String} the cleaned string
+*/
 QMLFile.trimComment = function(commentString) {
     if (!commentString) return;
 
@@ -82,6 +89,21 @@ QMLFile.trimComment = function(commentString) {
         trim();
     return trimComment;
 }
+/**
+ * Remove single and multi-lines comments except for i18n comment style.
+ *
+ * @private
+ * @param {String} string the string to clean
+ * @returns {String} the cleaned string
+ */
+QMLFile.trimComments = function(data) {
+    if (!data) return;
+    // comment style: // , /* */ single, multi line
+    var trimData = data.replace(/\/\/(?!\:|\~)\s*((?!i18n).)*[$/\n]/g, "").
+                    replace(/\/\*+([^*]|\*(?!\/))*\*+\//g, "").
+                    replace(/\/\*(.*)\*\//g, "");
+    return trimData;
+};
 
 QMLFile.makeContextValue = function(fullpath) {
     if (!fullpath) return;
@@ -105,6 +127,9 @@ var reI18nExtraComment = new RegExp(/\/\/~\s+(.*)\n/);
  */
 QMLFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+
+    data = QMLFile.trimComments(data);
+
     this.resourceIndex = 0;
 
     var match, key;

--- a/QMLFile.js
+++ b/QMLFile.js
@@ -72,7 +72,7 @@ QMLFile.prototype.makeKey = function(source) {
 };
 
 /**
-* Remove single and multi-lines comments except for i18n comment style.
+* Clean up i18n comments to be displayed neatly
 *
 * @private
 * @param {String} string the string to clean
@@ -96,7 +96,7 @@ QMLFile.trimComment = function(commentString) {
  * @param {String} string the string to clean
  * @returns {String} the cleaned string
  */
-QMLFile.trimComments = function(data) {
+QMLFile.removeCommentLines = function(data) {
     if (!data) return;
     // comment style: // , /* */ single, multi line
     var trimData = data.replace(/\/\/(?!\:|\~)\s*((?!i18n).)*[$/\n]/g, "").
@@ -128,7 +128,7 @@ var reI18nExtraComment = new RegExp(/\/\/~\s+(.*)\n/);
 QMLFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
 
-    data = QMLFile.trimComments(data);
+    data = QMLFile.removeCommentLines(data);
 
     this.resourceIndex = 0;
 

--- a/QMLFile.js
+++ b/QMLFile.js
@@ -1,7 +1,7 @@
 /*
  * QMLFile.js - plugin to extract resources from a QML source code file
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/QMLFileType.js
+++ b/QMLFileType.js
@@ -1,7 +1,7 @@
 /*
  * QMLFileType.js - Represents a collection of QML files
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ ilib-webos-loctool-qml is a plugin for the loctool allows it to read and localiz
 
 ## Release Notes
 v1.2.0
+* Remove commented lines before parsing so that strings in the comments will not be extracted.
 
 v1.1.1
 * Updated code to print log with log4js.
@@ -17,7 +18,7 @@ v1.0.0
 
 ## License
 
-Copyright © 2020, JEDLSoft
+Copyright © 2020-2021, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ilib-webos-loctool-qml is a plugin for the loctool allows it to read and localiz
 
 ## Release Notes
 v1.2.0
-* Remove commented lines before parsing so that strings in the comments will not be extracted.
+* Removed commented lines before parsing so that strings in the comments will not be extracted.
 
 v1.1.1
 * Updated code to print log with log4js.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 ilib-webos-loctool-qml is a plugin for the loctool allows it to read and localize qml files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.2.0
+
 v1.1.1
 * Updated code to print log with log4js.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-qml",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "main": "./QMLFileType.js",
     "description": "A loctool plugin that knows how to process qml files",
     "license": "Apache-2.0",

--- a/test/assertExtras.js
+++ b/test/assertExtras.js
@@ -1,7 +1,7 @@
 /*
  * assertExtras.js - extra assertion types to use with nodeunit
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testQMLFile.js
+++ b/test/testQMLFile.js
@@ -1,7 +1,7 @@
 /*
  * testQMLFile.js - test the qml file handler object.
  *
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testQMLFileType.js
+++ b/test/testQMLFileType.js
@@ -1,7 +1,7 @@
 /*
  * testQMLFileType.js - test the QML file type handler object.
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuite.js
+++ b/test/testSuite.js
@@ -1,7 +1,7 @@
 /*
  * testSuite.js - test suite for this directory
  * 
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -1,7 +1,7 @@
 /*
  * testSuiteFiles.js - list the test files in this directory
  * 
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testfiles/t7.qml
+++ b/test/testfiles/t7.qml
@@ -1,0 +1,19 @@
+property var strings: {
+    "test1": qsTr("1: Test String for qsTr"),
+    "test7": qsTr("1: Test String for qsTr", "7: disambiguation string"), // i18n webos comment
+}
+
+property var strings: {
+    "invalidFormat": {
+        // full: qsTr("Invalid Format") + _emptyString
+    },
+    "channelBlocked": {
+        //full: qsTr("Channel Locked") + _emptyString, //i18n Title of screensaver for blocking channel.
+        body: ziggoChannelLockBodyStr + "\n" + okButtonForUnlockStr
+    }, /*
+    "acasPRVContractTime8608": {
+        body: qsTr("Out of contract time") + _emptyString //i18n Translate only "JP"
+    },*/
+}
+
+qsTr("My Channels") // i18n some comment messages...


### PR DESCRIPTION
* Remove commented lines except for the i18n comment style before parsing so that strings in the comments will not be extracted.
* Add related test cases

* i18n comment style which should not be deleted
```
// i18n hello
//: hello
//~ hello
```