### PR TITLE
Updated code-related i18n comment extractor part

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 ilib-webos-loctool-qml is a plugin for the loctool allows it to read and localize qml files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.3.0
+* Updated code to extract the i18n comment part more appropriately. If webOS style comments exist, The [general comment style](https://doc.qt.io/qt-5/qtquick-internationalization.html) is ignored.
+
 v1.2.0
 * Removed commented lines before parsing so that strings in the comments will not be extracted.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-qml",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "main": "./QMLFileType.js",
     "description": "A loctool plugin that knows how to process qml files",
     "license": "Apache-2.0",

--- a/test/testQMLFile.js
+++ b/test/testQMLFile.js
@@ -1084,7 +1084,7 @@ module.exports.qmlfile = {
         test.ok(r);
         test.equal(r.getSource(), "1: Test String for qsTr");
         test.equal(r.getKey(), "1: Test String for qsTr");
-        test.equal(r.getComment(), "--> main comment for the translator");
+        test.equal(r.getComment(), "--> main comment for the translator--> Additional comment for the translator");
 
         /*sourceHash = utils.hashKey('1: Test String for qsTr');
         var r = set.get(SourceContextResourceString.hashKey("app", "t4", set.sourceLocale, "7: disambiguation string", "x-qml", undefined, sourceHash));

--- a/test/testQMLFile.js
+++ b/test/testQMLFile.js
@@ -1066,7 +1066,7 @@ module.exports.qmlfile = {
         test.done();
     },
     testQMLFileTest4: function(test) {
-        test.expect(6);
+        test.expect(12);
 
         var qf = new QMLFile({
             project: p,
@@ -1077,7 +1077,7 @@ module.exports.qmlfile = {
         qf.extract();
 
         var set = qf.getTranslationSet();
-        test.equal(set.size(), 1);
+        test.equal(set.size(), 2);
 
         var sourceHash = utils.hashKey('1: Test String for qsTr');
         var r = set.get(SourceContextResourceString.hashKey("app", "t4", set.sourceLocale,"1: Test String for qsTr", "x-qml", undefined, sourceHash));
@@ -1086,7 +1086,7 @@ module.exports.qmlfile = {
         test.equal(r.getKey(), "1: Test String for qsTr");
         test.equal(r.getComment(), "--> main comment for the translator--> Additional comment for the translator");
 
-        /*sourceHash = utils.hashKey('1: Test String for qsTr');
+        sourceHash = utils.hashKey('1: Test String for qsTr');
         var r = set.get(SourceContextResourceString.hashKey("app", "t4", set.sourceLocale, "7: disambiguation string", "x-qml", undefined, sourceHash));
         test.ok(r);
         test.equal(r.getSource(), "1: Test String for qsTr");
@@ -1098,7 +1098,7 @@ module.exports.qmlfile = {
         test.ok(r);
 
         test.equal(r[0].getSource(), "1: Test String for qsTr");
-        test.equal(r[0].getKey(), "7: disambiguation string");*/
+        test.equal(r[0].getKey(), "7: disambiguation string");
 
         test.done();
     },
@@ -1418,7 +1418,7 @@ module.exports.qmlfile = {
         qf.extract();
 
         var set = qf.getTranslationSet();
-        test.equal(set.size(), 3);
+        test.equal(set.size(), 5);
 
         var sourceHash = utils.hashKey("My Channels");
         var r = set.get(SourceContextResourceString.hashKey("app", "t7", set.sourceLocale, "My Channels", "x-qml", undefined, sourceHash));
@@ -1426,6 +1426,37 @@ module.exports.qmlfile = {
         test.equal(r.getSource(), "My Channels");
         test.equal(r.getKey(), "My Channels");
         test.equal(r.getComment(), "some comment messages...");
+
+        test.done();
+    },
+    testQMLFileTestFileComment: function(test) {
+        test.expect(10);
+
+        var qf = new QMLFile({
+            project: p,
+            pathName: "./t7.qml",
+            type: qmlft
+        });
+        test.ok(qf);
+        // should attempt to read the file and not fail
+        qf.extract();
+
+        var set = qf.getTranslationSet();
+        test.equal(set.size(), 5);
+
+        var sourceHash = utils.hashKey("Channel Locked");
+        var r = set.get(SourceContextResourceString.hashKey("app", "t7", set.sourceLocale, "Channel Locked", "x-qml", undefined, sourceHash));
+        test.ok(r);
+        test.equal(r.getSource(), "Channel Locked");
+        test.equal(r.getKey(), "Channel Locked");
+        test.equal(r.getComment(), "--> main comment for the translator");
+
+        var sourceHash = utils.hashKey("Invalid Format");
+        var r = set.get(SourceContextResourceString.hashKey("app", "t7", set.sourceLocale, "Invalid Format", "x-qml", undefined, sourceHash));
+        test.ok(r);
+        test.equal(r.getSource(), "Invalid Format");
+        test.equal(r.getKey(), "Invalid Format");
+        test.equal(r.getComment(), "--> main comment for the translator--> Additional comment for the translator");
 
         test.done();
     },

--- a/test/testQMLFile.js
+++ b/test/testQMLFile.js
@@ -502,7 +502,7 @@ module.exports.qmlfile = {
         test.ok(r);
         test.equal(r.getSource(), "My Channels");
         test.equal(r.getKey(), "My Channels");
-        test.equal(r.getComment(), "General main Comment webOS Comment");
+        test.equal(r.getComment(), "webOS Comment");
 
         test.done();
     },
@@ -530,7 +530,7 @@ module.exports.qmlfile = {
         test.ok(r);
         test.equal(r.getSource(), "My Channels");
         test.equal(r.getKey(), "My Channels");
-        test.equal(r.getComment(), "General main Comment webOS Comment General additional Comment");
+        test.equal(r.getComment(), "webOS Comment");
 
         test.done();
     },
@@ -581,7 +581,7 @@ module.exports.qmlfile = {
         test.ok(r);
         test.equal(r.getSource(), "My Channels\n \t ...");
         test.equal(r.getKey(), "number");
-        test.equal(r.getComment(), "General main Comment info to translator");
+        test.equal(r.getComment(), "info to translator");
 
         test.done();
     },
@@ -608,7 +608,7 @@ module.exports.qmlfile = {
         test.ok(r);
         test.equal(r.getSource(), "My Channels\n \t ...");
         test.equal(r.getKey(), "number");
-        test.equal(r.getComment(), "General main Comment info to translator");
+        test.equal(r.getComment(), "info to translator");
 
         test.done();
     },
@@ -635,7 +635,7 @@ module.exports.qmlfile = {
         var r = set.getBySource("My Channels\n \t ...");
         test.ok(r);
         test.equal(r.getSource(), "My Channels\n \t ...");
-        test.equal(r.getComment(), "comment1 comment3 comment2");
+        test.equal(r.getComment(), "comment3");
 
         test.done();
     },
@@ -1066,7 +1066,7 @@ module.exports.qmlfile = {
         test.done();
     },
     testQMLFileTest4: function(test) {
-        test.expect(12);
+        test.expect(6);
 
         var qf = new QMLFile({
             project: p,
@@ -1077,16 +1077,16 @@ module.exports.qmlfile = {
         qf.extract();
 
         var set = qf.getTranslationSet();
-        test.equal(set.size(), 2);
+        test.equal(set.size(), 1);
 
         var sourceHash = utils.hashKey('1: Test String for qsTr');
         var r = set.get(SourceContextResourceString.hashKey("app", "t4", set.sourceLocale,"1: Test String for qsTr", "x-qml", undefined, sourceHash));
         test.ok(r);
         test.equal(r.getSource(), "1: Test String for qsTr");
         test.equal(r.getKey(), "1: Test String for qsTr");
-        test.equal(r.getComment(), "--> main comment for the translator  --> Additional comment for the translator");
+        test.equal(r.getComment(), "--> main comment for the translator");
 
-        sourceHash = utils.hashKey('1: Test String for qsTr');
+        /*sourceHash = utils.hashKey('1: Test String for qsTr');
         var r = set.get(SourceContextResourceString.hashKey("app", "t4", set.sourceLocale, "7: disambiguation string", "x-qml", undefined, sourceHash));
         test.ok(r);
         test.equal(r.getSource(), "1: Test String for qsTr");
@@ -1098,7 +1098,7 @@ module.exports.qmlfile = {
         test.ok(r);
 
         test.equal(r[0].getSource(), "1: Test String for qsTr");
-        test.equal(r[0].getKey(), "7: disambiguation string");
+        test.equal(r[0].getKey(), "7: disambiguation string");*/
 
         test.done();
     },

--- a/test/testfiles/t1.qml
+++ b/test/testfiles/t1.qml
@@ -9,6 +9,7 @@ QtObject {
     }
     property var strings: {
         "invalidFormat": {
+            //: --> main comment for the translator
             full: qsTr("Invalid Format") + _emptyString
         },
         "channelBlocked": {

--- a/test/testfiles/t4.qml
+++ b/test/testfiles/t4.qml
@@ -2,5 +2,5 @@ property var strings: {
 	//: --> main comment for the translator
 	//~ --> Additional comment for the translator
 	"test1": qsTr("1: Test String for qsTr"),
-	//"test7": qsTr("1: Test String for qsTr", "7: disambiguation string"), // i18n webos comment
+	"test7": qsTr("1: Test String for qsTr", "7: disambiguation string"), // i18n webos comment
 }

--- a/test/testfiles/t4.qml
+++ b/test/testfiles/t4.qml
@@ -2,5 +2,5 @@ property var strings: {
 	//: --> main comment for the translator
 	//~ --> Additional comment for the translator
 	"test1": qsTr("1: Test String for qsTr"),
-	"test7": qsTr("1: Test String for qsTr", "7: disambiguation string"), // i18n webos comment
+	//"test7": qsTr("1: Test String for qsTr", "7: disambiguation string"), // i18n webos comment
 }

--- a/test/testfiles/t7.qml
+++ b/test/testfiles/t7.qml
@@ -15,5 +15,12 @@ property var strings: {
         body: qsTr("Out of contract time") + _emptyString //i18n Translate only "JP"
     },*/
 }
-
+//: --> main comment for the translator
 qsTr("My Channels") // i18n some comment messages...
+
+//: --> main comment for the translator
+qsTr("Channel Locked")
+
+//: --> main comment for the translator
+//~ --> Additional comment for the translator
+qsTr("Invalid Format")


### PR DESCRIPTION
Updated code-related i18n comment extractor part.
Regarding i18n comment, There two style exist.

1) // i18n <- webOS style
2) //: , //~  (general qml documentation)

When webOS style i18n comment is found, extract that as comments, if not, Re-search if general qml comments style exists.
In order to search lines easily, the plugin has additional data that split by line. Searches the first two lines based on a string.
