### PR TITLE
Fix to handle when pseudoLocales type is object

### DIFF
--- a/QMLFileType.js
+++ b/QMLFileType.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
 var path = require("path");
 var log4js = require("log4js");
 var QMLFile = require("./QMLFile.js");
@@ -37,19 +36,29 @@ var QMLFileType = function(project) {
     this.newres = this.API.newTranslationSet(project.getSourceLocale());
     this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
 
-    this.pseudos = {};
-
     if (typeof project.pseudoLocale === "string") {
         project.pseudoLocale = [project.pseudoLocale];
     }
 
     // generate all the pseudo bundles we'll need
-    project.pseudoLocale && project.pseudoLocale.forEach(function(locale) {
-        var pseudo = this.API.getPseudoBundle(locale, this, project);
-        if (pseudo) {
-            this.pseudos[locale] = pseudo;
+    if (project.pseudoLocale && Array.isArray(project.pseudoLocale)) {
+        this.pseudos = {};
+        project.pseudoLocale && project.pseudoLocale.forEach(function(locale) {
+            var pseudo = this.API.getPseudoBundle(locale, this, project);
+            if (pseudo) {
+                this.pseudos[locale] = pseudo;
+            }
+        }.bind(this));
+    }
+    if (project.pseudoLocales && typeof project.pseudoLocales == 'object') {
+        this.pseudos = {};
+        for (locale in project.pseudoLocales) {
+            var pseudo = this.API.getPseudoBundle(locale, this, project);
+            if (pseudo) {
+                this.pseudos[locale] = pseudo;
+            }
         }
-    }.bind(this));
+    }
 
     // for use with missing strings
     if (!project.settings.nopseudo) {

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 ilib-webos-loctool-qml is a plugin for the loctool allows it to read and localize qml files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.3.3
+* Fix pseudo localization to work properly
+
 v1.3.2
 * Updated dependent module version to have the latest one. (loctool: 2.13.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-qml",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "main": "./QMLFileType.js",
     "description": "A loctool plugin that knows how to process qml files",
     "license": "Apache-2.0",


### PR DESCRIPTION
* In order to work correctly with loctool change: https://github.com/iLib-js/loctool/pull/165
  * same change: https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/24
* plugin should handle additional case  `project.psseudoLocales` and type is  `object` 
