### PR TITLE
Fixed issue not to filter newline character for window

### DIFF
--- a/QMLFile.js
+++ b/QMLFile.js
@@ -98,7 +98,7 @@ QMLFile.removeCommentLines = function(data) {
     if (!data) return;
 
     // comment style: // , /* */ single, multi line
-    var trimData = data.replace(/\r(\n)*/g, "\n").  // new line character for window
+    var trimData = data.replace(/\r(\n)*/g, "\n").  // newline character for window
                     replace(/\/\/(?!\:|\~)\s*((?!i18n).)*[$/\n]/g, "").
                     replace(/\/\*+([^*]|\*(?!\/))*\*+\//g, "").
                     replace(/\/\*(.*)\*\//g, "");

--- a/QMLFile.js
+++ b/QMLFile.js
@@ -96,8 +96,10 @@ QMLFile.trimComment = function(commentString) {
  */
 QMLFile.removeCommentLines = function(data) {
     if (!data) return;
+
     // comment style: // , /* */ single, multi line
-    var trimData = data.replace(/\/\/(?!\:|\~)\s*((?!i18n).)*[$/\n]/g, "").
+    var trimData = data.replace(/\r(\n)*/g, "\n").  // new line character for window
+                    replace(/\/\/(?!\:|\~)\s*((?!i18n).)*[$/\n]/g, "").
                     replace(/\/\*+([^*]|\*(?!\/))*\*+\//g, "").
                     replace(/\/\*(.*)\*\//g, "");
     return trimData;

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ v1.3.6
 * Updated dependencies
 * Used the logger provided by the loctool instead of using log4js directly.
 * Added node 16 version testing for circleCI ( minimum version of node is v10)
-* Fixed issue not to filter newline character for window.
+* Fixed an issue not to filter newline character for window.
 
 v1.3.5
 * Add `js` to the list of file extensions that this plugin handles.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ ilib-webos-loctool-qml is a plugin for the loctool allows it to read and localiz
 
 ## Release Notes
 v1.3.6
-* updated dependencies
-* Use the logger provided by the loctool instead of using log4js directly.
-* Add node 16 version testing for circleCI ( minimum version of node is v10)
+* Updated dependencies
+* Used the logger provided by the loctool instead of using log4js directly.
+* Added node 16 version testing for circleCI ( minimum version of node is v10)
+* Fixed issue not to filter newline character for window.
 
 v1.3.5
 * Add `js` to the list of file extensions that this plugin handles.

--- a/test/testQMLFile.js
+++ b/test/testQMLFile.js
@@ -1514,6 +1514,31 @@ module.exports.qmlfile = {
         test.ok(qf);
 
         qf.parse('        \n'+
+            '    /* qsTr("Today") // i18n some comment messages... */\n' +
+            '    //some comment messages...\n' +
+            '    // qsTr("Another day")\n' +
+            '    //: qsTr("(1) Last day")\r\n' +
+            '    //~ qsTr("(2) Some day")\r' +
+            '    // i18n qsTr("(3) First day")\r\n' +
+            '    // qsTr("Another day (1)")\r\n' +
+            '    // qsTr("Another day (2)")\r' +
+            '\n');
+
+        var set = qf.getTranslationSet();
+        test.equal(set.size(), 3);
+        test.done();
+    },
+    testQMLFileParseCommentedWindowStyle2: function(test) {
+        test.expect(2);
+
+        var qf = new QMLFile({
+            project: p,
+            pathName: undefined,
+            type: qmlft
+        });
+        test.ok(qf);
+
+        qf.parse('        \n'+
         '    // qsTr("Another day")\n' +
         '    // qsTr("Another day (1)")\r\n' +
         '    // qsTr("Another day (2)")\r' +
@@ -1522,5 +1547,5 @@ module.exports.qmlfile = {
         var set = qf.getTranslationSet();
         test.equal(set.size(), 0);
         test.done();
-    },
+    }
 }

--- a/test/testQMLFile.js
+++ b/test/testQMLFile.js
@@ -1,7 +1,7 @@
 /*
  * testQMLFile.js - test the qml file handler object.
  *
- * Copyright (c) 2020-2021, JEDLSoft
+ * Copyright (c) 2020-2022, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1501,6 +1501,26 @@ module.exports.qmlfile = {
 
         var set = qf.getTranslationSet();
         test.equal(set.size(), 3);
+        test.done();
+    },
+    testQMLFileParseCommentedWindowStyle: function(test) {
+        test.expect(2);
+
+        var qf = new QMLFile({
+            project: p,
+            pathName: undefined,
+            type: qmlft
+        });
+        test.ok(qf);
+
+        qf.parse('        \n'+
+        '    // qsTr("Another day")\n' +
+        '    // qsTr("Another day (1)")\r\n' +
+        '    // qsTr("Another day (2)")\r' +
+        '\n');
+
+        var set = qf.getTranslationSet();
+        test.equal(set.size(), 0);
         test.done();
     },
 }


### PR DESCRIPTION
 Fixed issue not to filter newline character for window.

note)
- \r = CR (Carriage Return) → Used as a new line character in Mac OS before X
- \n = LF (Line Feed) → Used as a new line character in Unix/Mac OS X
- \r\n = CR + LF → Used as a new line character in Windows
