### PR TITLE
Updated not to load common data repeatedly if it's loaded from another plugin in a project

### DIFF
--- a/QMLFileType.js
+++ b/QMLFileType.js
@@ -130,9 +130,17 @@ QMLFileType.prototype.write = function(translations, locales) {
         }.bind(this));
     var customInheritLocale;
 
-    if (this.commonPath && !this.isloadCommonData) {
-        this._loadCommonXliff();
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().includes("common"))) {
         this.isloadCommonData = true;
+    }
+
+    if (this.commonPath) {
+        if (!this.isloadCommonData) {
+            this._loadCommonXliff();
+            this.isloadCommonData = true;
+        } else {
+            this._addComonDatatoTranslationSet(translations);
+        }
     }
 
     for (var i = 0; i < resources.length; i++) {
@@ -283,6 +291,18 @@ QMLFileType.prototype.write = function(translations, locales) {
         }
     }
 };
+
+QMLFileType.prototype._addComonDatatoTranslationSet = function(tsdata) {
+    var prots = this.project.getRepository().getTranslationSet();
+    var commonts = tsdata.getBy({project: "common"});
+    if (commonts.length > 0){
+        this.commonPrjName = commonts[0].getProject();
+        this.commonPrjType = commonts[0].getDataType();
+        commonts.forEach(function(ts){
+            prots.add(ts);
+        }.bind(this));
+    }
+}
 
 QMLFileType.prototype._loadCommonXliff = function() {
     if (fs.existsSync(this.commonPath)){

--- a/QMLFileType.js
+++ b/QMLFileType.js
@@ -130,7 +130,7 @@ QMLFileType.prototype.write = function(translations, locales) {
         }.bind(this));
     var customInheritLocale;
 
-    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().includes("common"))) {
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().indexOf("common") !== -1)) {
         this.isloadCommonData = true;
     }
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 ilib-webos-loctool-qml is a plugin for the loctool allows it to read and localize qml files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.6.0
+* Updated not to load common data repeatedly if it's loaded from another plugin in a project.
+
 v1.5.1
 * Fixed issues where didn't handle single quotes and multi-line properly.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-qml",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "main": "./QMLFileType.js",
     "description": "A loctool plugin that knows how to process qml files",
     "license": "Apache-2.0",


### PR DESCRIPTION
* Updated not to load common data repeatedly if it's loaded from another plugin in a project.
  * Implemented not to load/read common data files if it's already loaded. only add data to the translation set.