### PR TITLE
Update for the test on node v20 in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,13 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: cimg/node:12.22.12
+          docker_image: cimg/node:12.22
       - test:
-          docker_image: cimg/node:14.21.3
+          docker_image: cimg/node:14.21
       - test:
-          docker_image: cimg/node:16.20.2
+          docker_image: cimg/node:16.20
       - test:
-          docker_image: cimg/node:18.17.1
+          docker_image: cimg/node:18.20
+      - test:
+          docker_image: cimg/node:20.15
       - test


### PR DESCRIPTION
Update for the test on node `v20` in circleCI. 
The node version of `webOS` has been updated to `v20.12.2`