### PR TITLE
Fixed newline issues where resources of source string containing '\n' were not generated

### DIFF
--- a/QMLFileType.js
+++ b/QMLFileType.js
@@ -108,28 +108,26 @@ QMLFileType.prototype._addResource = function(resFileType, translated, res, loca
 QMLFileType.prototype._getTranslationWithNewline = function(db, translated, res, locale, isCommon) {
     var newtranslated = translated;
 
-    if (!newtranslated && res.getSource().includes("\n")) {
-        var newlinerestored = res.getSource().replace(/\n/g, "\\n");
-        this.logger.debug("_getTranslationWithNewline: "+newlinerestored);
-        var newres = res.clone();
-        newres.source = newlinerestored;
-        newres.sourcehash = this.API.utils.hashKey(newlinerestored);
-        var manipulateKey;
-        if (isCommon) {
-            manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey().replace(/\n/g, "\\n"), this.commonPrjType, res.getFlavor());
-        }
-        else {
-            manipulateKey = newres.cleanHashKeyForTranslation(locale).replace(newres.getContext(), "").replace(/\n/g, "\\n");
-        }
-        db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
-            if (translated) {
-                translated.source = res.source;
-                translated.reskey = res.reskey;
-                translated.setTarget(translated.getTarget().replace(/\\n/g, "\n"));
-                newtranslated = translated;
-            }
-        }.bind(this));
+    var newlinerestored = res.getSource().replace(/\n/g, "\\n");
+    this.logger.debug("_getTranslationWithNewline: "+newlinerestored);
+    var newres = res.clone();
+    newres.source = newlinerestored;
+    newres.sourcehash = this.API.utils.hashKey(newlinerestored);
+    var manipulateKey;
+    if (isCommon) {
+        manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey().replace(/\n/g, "\\n"), this.commonPrjType, res.getFlavor());
     }
+    else {
+        manipulateKey = newres.cleanHashKeyForTranslation(locale).replace(newres.getContext(), "").replace(/\n/g, "\\n");
+    }
+    db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
+        if (translated) {
+            translated.source = res.source;
+            translated.reskey = res.reskey;
+            translated.setTarget(translated.getTarget().replace(/\\n/g, "\n"));
+            newtranslated = translated;
+        }
+    }.bind(this));
 
     return newtranslated;
 }
@@ -186,28 +184,37 @@ QMLFileType.prototype.write = function(translations, locales) {
                     db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
                     var r = translated;
 
-                    translated = this._getTranslationWithNewline(db, translated, res, locale, false);
-                    r = translated;
+                    if (!translated && res.getSource().includes("\n")) {
+                        translated = this._getTranslationWithNewline(db, translated, res, locale, false);
+                        r = translated;
+                    }
 
                     if (!translated && this.isloadCommonData) {
                         var manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey(), this.commonPrjType, res.getFlavor());
                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
-                            translated = this._getTranslationWithNewline(db, translated, res, locale, true);
-                            r = translated;
+                            if (!translated && res.getSource().includes("\n")) {
+                                translated = this._getTranslationWithNewline(db, translated, res, locale, true);
+                                r = translated;
+                            }
 
                             if (translated) {
                                 this._addResource(resFileType, translated, res, locale);
                             } else if(!translated && customInheritLocale){
                                 var manipulateKey = res.cleanHashKeyForTranslation(customInheritLocale).replace(res.getContext(), "");
                                 db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
-                                    translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, false);
-                                    r = translated;
+                                    if (!translated && res.getSource().includes("\n")) {
+                                        translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, false);
+                                        r = translated;
+                                    }
 
                                     if (!translated){
                                         var manipulateKey = ResourceString.hashKey(this.commonPrjName, customInheritLocale, res.getKey(), this.commonPrjType, res.getFlavor());
                                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
-                                            translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, true);
-                                            r = translated;
+                                            if (!translated && res.getSource().includes("\n")) {
+                                                translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, true);
+                                                r = translated;
+                                            }
+
                                             if (translated){
                                                 this._addResource(resFileType, translated, res, locale);
                                             } else {
@@ -238,8 +245,10 @@ QMLFileType.prototype.write = function(translations, locales) {
                         var manipulateKey = res.cleanHashKeyForTranslation(customInheritLocale).replace(res.getContext(),"");
                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
                             var r = translated;
-                            translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, false);
-                            r = translated;
+                            if (!translated && res.getSource().includes("\n")) {
+                                translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, false);
+                                r = translated;
+                            }
 
                             if (translated){
                                 this._addResource(resFileType, translated, res, locale);

--- a/QMLFileType.js
+++ b/QMLFileType.js
@@ -105,6 +105,35 @@ QMLFileType.prototype._addResource = function(resFileType, translated, res, loca
     file.addResource(resource);
 }
 
+QMLFileType.prototype._getTranslationWithNewline = function(db, translated, res, locale, isCommon) {
+    var newtranslated = translated;
+
+    if (!newtranslated && res.getSource().includes("\n")) {
+        var newlinerestored = res.getSource().replace(/\n/g, "\\n");
+        this.logger.debug("_getTranslationWithNewline: "+newlinerestored);
+        var newres = res.clone();
+        newres.source = newlinerestored;
+        newres.sourcehash = this.API.utils.hashKey(newlinerestored);
+        var manipulateKey;
+        if (isCommon) {
+            manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey().replace(/\n/g, "\\n"), this.commonPrjType, res.getFlavor());
+        }
+        else {
+            manipulateKey = newres.cleanHashKeyForTranslation(locale).replace(newres.getContext(), "").replace(/\n/g, "\\n");
+        }
+        db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
+            if (translated) {
+                translated.source = res.source;
+                translated.reskey = res.reskey;
+                translated.setTarget(translated.getTarget().replace(/\\n/g, "\n"));
+                newtranslated = translated;
+            }
+        }.bind(this));
+    }
+
+    return newtranslated;
+}
+
 /**
  * Write out the aggregated resources for this file type. In
  * some cases, the string are written out to a common resource
@@ -157,17 +186,28 @@ QMLFileType.prototype.write = function(translations, locales) {
                     db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
                     var r = translated;
 
+                    translated = this._getTranslationWithNewline(db, translated, res, locale, false);
+                    r = translated;
+
                     if (!translated && this.isloadCommonData) {
                         var manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey(), this.commonPrjType, res.getFlavor());
                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
+                            translated = this._getTranslationWithNewline(db, translated, res, locale, true);
+                            r = translated;
+
                             if (translated) {
                                 this._addResource(resFileType, translated, res, locale);
                             } else if(!translated && customInheritLocale){
                                 var manipulateKey = res.cleanHashKeyForTranslation(customInheritLocale).replace(res.getContext(), "");
                                 db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
+                                    translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, false);
+                                    r = translated;
+
                                     if (!translated){
                                         var manipulateKey = ResourceString.hashKey(this.commonPrjName, customInheritLocale, res.getKey(), this.commonPrjType, res.getFlavor());
                                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
+                                            translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, true);
+                                            r = translated;
                                             if (translated){
                                                 this._addResource(resFileType, translated, res, locale);
                                             } else {
@@ -198,6 +238,9 @@ QMLFileType.prototype.write = function(translations, locales) {
                         var manipulateKey = res.cleanHashKeyForTranslation(customInheritLocale).replace(res.getContext(),"");
                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
                             var r = translated;
+                            translated = this._getTranslationWithNewline(db, translated, res, customInheritLocale, false);
+                            r = translated;
+
                             if (translated){
                                 this._addResource(resFileType, translated, res, locale);
                             } else {

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+### v1.7.5
+* Fixed newline issues where source string containing '\n' were not extracted
+
 ### v1.7.4
 * Updated dependencies. (loctool: 2.24.0)
 * Converted all the unit tests from `nodeunit` to `jest`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ file for more details.
 
 ## Release Notes
 ### v1.7.5
-* Fixed newline issues where source string containing '\n' were not extracted
+* Fixed newline issues where resources of source string containing '\n' were not generated
 
 ### v1.7.4
 * Updated dependencies. (loctool: 2.24.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-qml",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "main": "./QMLFileType.js",
     "description": "A loctool plugin that knows how to process qml files",
     "license": "Apache-2.0",


### PR DESCRIPTION
Fixed newline issues where resources of source string containing '\n' were not generated
If source and target string has multiple lines, one line with newline char('\n') is allowed in webOS xliff.

Sample to check: https://github.com/iLib-js/ilib-loctool-samples/pull/71